### PR TITLE
Add support for picard demultiplexing

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,16 +1,65 @@
 [![Bioconda](https://img.shields.io/conda/dn/bioconda/digestiflow-cli.svg?label=Bioconda)](https://bioconda.github.io/recipes/digestiflow-cli/README.html)
 [![Build Status](https://travis-ci.org/bihealth/digestiflow-cli.svg?branch=master)](https://travis-ci.org/bihealth/digestiflow)
 
-
 =================
 DigestiFlow Demux
 =================
 
-Demultiplexing support for DigestiFlow.
+A command line client tool to perform semiautomatic demultiplexing of Illumina flowcells using data from Digestiflow Web.
+
+------------
+Installation
+------------
+
+The recommended way to install is to install the `digestiflow-demux` package from Bioconda.
+
+-----
+Usage
+-----
+
+First, create a ``~/.digestiflowrc.toml`` file to configure access to the Digestiflow Web API.
 
 ```toml
-# cat ~/.digestiflowrc.toml
 [web]
-url = "https://flowcells.bihealth.org"
-token = "<user token>"
+# URL to your Digestiflow instance. "$url/api" must be the API entry URL.
+url = "https://flowcells.example.org"
+# The secret token to use for the the REST API, as created through the Web UI.
+token = "secretsecretsecretsecretsecretsecretsecretsecretsecretsecretsecr"
+```
+
+Then, you can use the ``digestiflow-demux`` command for demultiplexing Illumina sequencing runs.
+
+```bash
+$ digestiflow-demux \
+    --project-uuid UUID \
+    path/to/output/dir \
+    path/to/input/runs \
+    path/to/input/second_run
+```
+
+The call will create one output directories in ``path/to/output/dir`` for each input run.
+Flow cell sample sheets will be pulled from the project with the given ``UUID``.
+
+-------------
+Configuration
+-------------
+
+The following shows all configuration settings loaded from ``~/.digestiflowrc.toml`` with their defaults.
+
+```toml
+[web]
+# URL to your Digestiflow instance. "$url/api" must be the API entry URL.
+url =
+# The secret token to use for the the REST API, as created through the Web UI.
+token =
+
+[demux]
+# UUID of the project to import to.
+project_uuid =
+# Whether or not to keep the working directory around (useful for debugging only).
+keep_work_dir = false
+# Whether or not to increase verbosity.
+verbose = false
+# Whether or not to decrease verbosity.
+quiet = false
 ```

--- a/digestiflow_demux/Snakefile
+++ b/digestiflow_demux/Snakefile
@@ -45,6 +45,13 @@ rule marker_file:
 # -------------------------------------------------------------------------------------------------
 # Perform demultiplexing.
 
+if config["demux_tool"] == "bcl2fastq":
+    ruleorder: demux > demux_picard
+elif config["demux_tool"] == "picard" and config["rta_version"] == 2:
+    ruleorder: demux_picard > demux
+else:
+    raise("Picard might only be used with rta version 2 at the moment")
+
 rule demux:
     input: out_prefix("SampleSheet.csv")
     output: get_result_files_demux(config)
@@ -55,6 +62,37 @@ rule demux:
         tiles_arg=get_tiles_arg(config),
     threads: config["cores"]
     wrapper: wrapper_path(bcl2fastq_wrapper(config))
+
+# Picard: either take configured lane or all lanes
+lanes_to_process = config.get("lanes")
+if not lanes_to_process:
+    lanes_to_process = [x+1 for x in range(config["flowcell"]["num_lanes"])]
+
+rule demux_picard:
+    input: metrics=expand(out_prefix("picard_barcodes/{lane}/metrics.txt"), lane=lanes_to_process),
+           sheets=expand(out_prefix("picard_barcodes/{lane}/samplesheet.txt"), lane=lanes_to_process)
+    output: get_result_files_demux(config)
+    params:
+        machine_name=config["flowcell"]["sequencing_machine"],
+        flowcell_token=config["flowcell"]["vendor_id"],
+        run_number=config["flowcell"]["run_number"],
+        read_structure=config["flowcell"]["current_reads"],
+        input_dir=config["input_dir"],
+        output_dir=config["output_dir"],
+        tiles_arg=get_tiles_arg(config),
+        lanes=lanes_to_process,
+    threads: config["cores"]
+    wrapper: wrapper_path("picard/basecalls_to_fastq")
+
+rule prepare_picard:
+    input: out_prefix("picard_barcodes/{lane}/barcodes.txt")
+    output: out_prefix("picard_barcodes/{lane}/metrics.txt")
+    params:
+        flowcell_token=config["flowcell"]["vendor_id"],
+        read_structure=config["flowcell"]["current_reads"],
+        input_dir=config["input_dir"],
+    threads: config["cores"]
+    wrapper: wrapper_path("picard/extract_barcodes")
 
 # -------------------------------------------------------------------------------------------------
 # Run FastQC.

--- a/digestiflow_demux/__main__.py
+++ b/digestiflow_demux/__main__.py
@@ -270,7 +270,8 @@ def main(argv=None):
         dest="tiles",
         help=(
             "Select tile regex; provide multiple times for multiple "
-            "regexes; conflicts with --lane"
+            "regexes with bcl2fastq. Picard will use the first tile. "
+            "Conflicts with --lane"
         ),
     )
 

--- a/digestiflow_demux/__main__.py
+++ b/digestiflow_demux/__main__.py
@@ -183,9 +183,10 @@ def run(config, output_dir, input_dirs, log_handler):
             if message and flowcell and client:
                 # Append log file to message in Digestiflow Web
                 log_handler.flush()
-                client.message_attach(
-                    flowcell["sodar_uuid"], message["sodar_uuid"], log_handler.stream
-                )
+                if not args.api_read_only:
+                    client.message_attach(
+                        flowcell["sodar_uuid"], message["sodar_uuid"], log_handler.stream
+                    )
                 # Truncate file after this flow cell to prevent confusion.
                 logging.debug("Starting new log file for new flow cell")
                 log_handler.stream.truncate()

--- a/digestiflow_demux/__main__.py
+++ b/digestiflow_demux/__main__.py
@@ -183,7 +183,7 @@ def run(config, output_dir, input_dirs, log_handler):
             if message and flowcell and client:
                 # Append log file to message in Digestiflow Web
                 log_handler.flush()
-                if not args.api_read_only:
+                if not config.api_read_only:
                     client.message_attach(
                         flowcell["sodar_uuid"], message["sodar_uuid"], log_handler.stream
                     )

--- a/digestiflow_demux/snakemake_support.py
+++ b/digestiflow_demux/snakemake_support.py
@@ -61,7 +61,7 @@ def undetermined_libraries(flowcell):
     for lane in lanes:
         result.append(
             {
-                "name": library["name"],
+                "name": "Undetermined",
                 "reference": library["reference"],
                 "barcode": "Undetermined",
                 "barcode2": "Undetermined",
@@ -120,7 +120,7 @@ def get_result_files_demux(config):
         return os.path.join(config["output_dir"], path)
 
     flowcell = config["flowcell"]
-    is_paired = flowcell["planned_reads"].count("T") > 1
+    is_paired = flowcell["current_reads"].count("T") > 1
     sample_map = build_sample_map(flowcell)
 
     for lib in flowcell["libraries"] + undetermined_libraries(flowcell):
@@ -138,7 +138,7 @@ def get_result_files_demux(config):
                 lane=lane,
             )
 
-            if config["rta_version"] == 1:
+            if config["rta_version"] == 1 or config["demux_tool"] == "picard":
                 for fname in lib_file_names(lib, config["rta_version"], is_paired, lane):
                     yield out_prefix("{out_dir}/{fname}".format(out_dir=out_dir, fname=fname))
             else:

--- a/digestiflow_demux/snakemake_support.py
+++ b/digestiflow_demux/snakemake_support.py
@@ -77,7 +77,7 @@ def lib_file_names(library, rta_version, is_paired, lane=None, seq=None, name=No
     assert rta_version in (1, 2)
     indices = [library["barcode"] or "NoIndex"]
     reads = ("R1", "R2") if is_paired else ("R1",)
-    lanes = ["L{03d}".format(lno) for lno in library["lanes"] if lane is None or lno == lane]
+    lanes = ["L{:03d}".format(lno) for lno in library["lanes"] if lane is None or lno == lane]
     if seq is None:
         seq = ""
     else:

--- a/digestiflow_demux/workflow.py
+++ b/digestiflow_demux/workflow.py
@@ -133,8 +133,7 @@ def write_sample_sheet_picard(flowcell, libraries, output_dir):
         barcode_rows = []
         samples_rows = []
         for lib in libraries.values():
-            print(lib)
-            output_prefix = "{name}/{flowcell}/L{lane:03d}/{name}".format(
+            output_prefix = "{lane}/{name}".format(
                 name=lib["name"], flowcell=flowcell["vendor_id"], lane=lane
             )
 

--- a/digestiflow_demux/workflow.py
+++ b/digestiflow_demux/workflow.py
@@ -152,7 +152,9 @@ def write_sample_sheet_picard(flowcell, libraries, output_dir):
 
         os.makedirs(os.path.join(output_dir, "picard_barcodes/{}".format(lane)), exist_ok=True)
 
-        with open(os.path.join(output_dir, "picard_barcodes/{}/barcodes.txt".format(lane)), "w") as bf, open(
+        with open(
+            os.path.join(output_dir, "picard_barcodes/{}/barcodes.txt".format(lane)), "w"
+        ) as bf, open(
             os.path.join(output_dir, "picard_barcodes/{}/samplesheet.txt".format(lane)), "w"
         ) as sf:
             barcodewriter = csv.writer(bf, delimiter="\t")

--- a/digestiflow_demux/wrappers/picard/basecalls_to_fastq/environment.yaml
+++ b/digestiflow_demux/wrappers/picard/basecalls_to_fastq/environment.yaml
@@ -1,0 +1,6 @@
+channels:
+- bioconda
+- conda-forge
+- defaults
+dependencies:
+- picard

--- a/digestiflow_demux/wrappers/picard/basecalls_to_fastq/wrapper.py
+++ b/digestiflow_demux/wrappers/picard/basecalls_to_fastq/wrapper.py
@@ -14,7 +14,7 @@ tiles = snakemake.config.get("tiles")  # noqa
 if not tiles:
     tiles = ""
 else:
-    tiles = "TILE_LIMIT=1".format(tiles)
+    tiles = "TILE_LIMIT=1"
 
 shell(
     r"""

--- a/digestiflow_demux/wrappers/picard/basecalls_to_fastq/wrapper.py
+++ b/digestiflow_demux/wrappers/picard/basecalls_to_fastq/wrapper.py
@@ -1,0 +1,56 @@
+"""Snakemake wrapper for picard ExtractIlluminaBarcodes.
+
+This file is part of Digestify Demux.
+"""
+
+from snakemake import shell
+
+__author__ = "Clemens Messerschmidt <clemens.messerschmidt@bihealth.de>"
+
+shell.executable("/bin/bash")
+
+# Get number of barcode mismatches, defaults to 0 for bcl2fastq v1.
+barcode_mismatches = snakemake.config.get("barcode_mismatches")
+if barcode_mismatches is None:
+    barcode_mismatches = 0
+
+
+shell(
+    r"""
+set -euo pipefail
+set -x
+
+# -------------------------------------------------------------------------------------------------
+# Setup Auto-cleaned Temporary Directory.
+
+export TMPDIR=$(mktemp -d)
+mkdir -p $TMPDIR
+
+pushd {snakemake.params.output_dir}
+
+for sheet in {snakemake.input.sheets}; do
+    prep_dir=$(dirname $sheet)
+    lane=$(basename $prep_dir)
+
+    echo $lane
+    echo $sheet
+
+    head -n 1000 $sheet
+
+    picard IlluminaBasecallsToFastq \
+        BASECALLS_DIR={snakemake.params.input_dir}/Data/Intensities/BaseCalls \
+        READ_STRUCTURE={snakemake.params.read_structure} \
+        LANE=$lane \
+        MULTIPLEX_PARAMS=$sheet \
+        BARCODES_DIR=$prep_dir \
+        RUN_BARCODE={snakemake.params.run_number} \
+        FLOWCELL_BARCODE={snakemake.params.flowcell_token} \
+        MACHINE_NAME={snakemake.params.machine_name} \
+        NUM_PROCESSORS={snakemake.threads} \
+        COMPRESS_OUTPUTS=true
+
+done
+
+popd
+"""
+)

--- a/digestiflow_demux/wrappers/picard/basecalls_to_fastq/wrapper.py
+++ b/digestiflow_demux/wrappers/picard/basecalls_to_fastq/wrapper.py
@@ -10,7 +10,7 @@ __author__ = "Clemens Messerschmidt <clemens.messerschmidt@bihealth.de>"
 shell.executable("/bin/bash")
 
 # Consider tiles to process.
-tiles = snakemake.config.get("tiles") # noqa
+tiles = snakemake.config.get("tiles")  # noqa
 if not tiles:
     tiles = ""
 else:

--- a/digestiflow_demux/wrappers/picard/basecalls_to_fastq/wrapper.py
+++ b/digestiflow_demux/wrappers/picard/basecalls_to_fastq/wrapper.py
@@ -9,13 +9,8 @@ __author__ = "Clemens Messerschmidt <clemens.messerschmidt@bihealth.de>"
 
 shell.executable("/bin/bash")
 
-# Get number of barcode mismatches, defaults to 0 for bcl2fastq v1.
-barcode_mismatches = snakemake.config.get("barcode_mismatches")
-if barcode_mismatches is None:
-    barcode_mismatches = 0
-
 # Consider tiles to process.
-tiles = snakemake.config.get("tiles")
+tiles = snakemake.config.get("tiles") # noqa
 if not tiles:
     tiles = ""
 else:

--- a/digestiflow_demux/wrappers/picard/extract_barcodes/environment.yaml
+++ b/digestiflow_demux/wrappers/picard/extract_barcodes/environment.yaml
@@ -1,0 +1,6 @@
+channels:
+- bioconda
+- conda-forge
+- defaults
+dependencies:
+- picard

--- a/digestiflow_demux/wrappers/picard/extract_barcodes/wrapper.py
+++ b/digestiflow_demux/wrappers/picard/extract_barcodes/wrapper.py
@@ -1,0 +1,40 @@
+"""Snakemake wrapper for picard ExtractIlluminaBarcodes.
+
+This file is part of Digestify Demux.
+"""
+
+from snakemake import shell
+
+__author__ = "Clemens Messerschmidt <clemens.messerschmidt@bihealth.de>"
+
+shell.executable("/bin/bash")
+
+# Get number of barcode mismatches, defaults to 0 for bcl2fastq v1.
+barcode_mismatches = snakemake.config.get("barcode_mismatches")
+if barcode_mismatches is None:
+    barcode_mismatches = 0
+
+
+shell(
+    r"""
+set -euo pipefail
+set -x
+
+# -------------------------------------------------------------------------------------------------
+# Setup Auto-cleaned Temporary Directory.
+
+export TMPDIR=$(mktemp -d)
+mkdir -p $TMPDIR
+
+# -------------------------------------------------------------------------------------------------
+
+picard ExtractIlluminaBarcodes \
+    BARCODE_FILE={snakemake.input} \
+    BASECALLS_DIR={snakemake.params.input_dir}/Data/Intensities/BaseCalls \
+    LANE={snakemake.wildcards.lane} \
+    METRICS_FILE={snakemake.output} \
+    OUTPUT_DIR=$(dirname {snakemake.output}) \
+    READ_STRUCTURE={snakemake.params.read_structure}
+
+"""
+)

--- a/digestiflow_demux/wrappers/picard/extract_barcodes/wrapper.py
+++ b/digestiflow_demux/wrappers/picard/extract_barcodes/wrapper.py
@@ -9,10 +9,10 @@ __author__ = "Clemens Messerschmidt <clemens.messerschmidt@bihealth.de>"
 
 shell.executable("/bin/bash")
 
-# Get number of barcode mismatches, defaults to 0 for bcl2fastq v1.
-barcode_mismatches = snakemake.config.get("barcode_mismatches")
+# Get number of barcode mismatches, defaults to 1.
+barcode_mismatches = snakemake.config.get("barcode_mismatches") # noqa
 if barcode_mismatches is None:
-    barcode_mismatches = 0
+    barcode_mismatches = 1
 
 
 shell(
@@ -34,7 +34,8 @@ picard ExtractIlluminaBarcodes \
     LANE={snakemake.wildcards.lane} \
     METRICS_FILE={snakemake.output} \
     OUTPUT_DIR=$(dirname {snakemake.output}) \
-    READ_STRUCTURE={snakemake.params.read_structure}
+    READ_STRUCTURE={snakemake.params.read_structure} \
+    MAX_MISMATCHES={barcode_mismatches}
 
 """
 )

--- a/digestiflow_demux/wrappers/picard/extract_barcodes/wrapper.py
+++ b/digestiflow_demux/wrappers/picard/extract_barcodes/wrapper.py
@@ -10,7 +10,7 @@ __author__ = "Clemens Messerschmidt <clemens.messerschmidt@bihealth.de>"
 shell.executable("/bin/bash")
 
 # Get number of barcode mismatches, defaults to 1.
-barcode_mismatches = snakemake.config.get("barcode_mismatches") # noqa
+barcode_mismatches = snakemake.config.get("barcode_mismatches")  # noqa
 if barcode_mismatches is None:
     barcode_mismatches = 1
 


### PR DESCRIPTION
- [x] Add command line switch `--demux-toolchain [bcl2fastq|picard`.
- [x] Add another command line switch `--api-read-only` that disables writing to the REST API.
- [x] Implement and test the feature.