### PR TITLE
Enable use of bcl2fastq packages from conda.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,12 @@ Digestiflow Demux Changelog
 HEAD (unreleased)
 -----------------
 
+- Enable use of bcl2fastq packages from conda.
+
+------
+v0.2.0
+------
+
 - Also writing out log files into target directories.
 - Adding ``--force-demultiplexing`` and ``--only-post-message`` command line arguments.
 - Wrapped Snakemake call writes ``.gz``-compressed logs now.

--- a/digestiflow_demux/snakemake_support.py
+++ b/digestiflow_demux/snakemake_support.py
@@ -120,7 +120,7 @@ def get_result_files_demux(config):
         return os.path.join(config["output_dir"], path)
 
     flowcell = config["flowcell"]
-    demux_reads = flowcell.get("demux_reads", flowcell["planned_reads"])
+    demux_reads = flowcell.get("demux_reads") or flowcell["planned_reads"]
     is_paired = demux_reads.count("T") > 1
     sample_map = build_sample_map(flowcell)
 

--- a/digestiflow_demux/wrappers/bcl2fastq/environment.yaml
+++ b/digestiflow_demux/wrappers/bcl2fastq/environment.yaml
@@ -2,6 +2,6 @@ channels:
 - bioconda
 - conda-forge
 - defaults
-#- http://cubi-conda.bihealth.org/cubiconda/
-#dependencies:
-#- bcl2fastq
+- bih-cubi
+dependencies:
+- bcl2fastq

--- a/digestiflow_demux/wrappers/bcl2fastq2/environment.yaml
+++ b/digestiflow_demux/wrappers/bcl2fastq2/environment.yaml
@@ -2,6 +2,6 @@ channels:
 - bioconda
 - conda-forge
 - defaults
-#- http://cubi-conda.bihealth.org/cubiconda/
-#dependencies:
-#- bcl2fastq2
+- bih-cubi
+dependencies:
+- bcl2fastq2

--- a/digestiflow_demux/wrappers/bcl2fastq2/wrapper.py
+++ b/digestiflow_demux/wrappers/bcl2fastq2/wrapper.py
@@ -42,7 +42,6 @@ bcl2fastq \
     --runfolder-dir {snakemake.params.input_dir} \
     --output-dir $TMPDIR/demux_out \
     --interop-dir $TMPDIR/interop_dir \
-    --demultiplexing-threads {bcl2fastq_threads} \
     --processing-threads {bcl2fastq_threads} \
     {snakemake.params.tiles_arg}
 


### PR DESCRIPTION
`--demultiplexing-threads` has been depracted by illumina, apparently.