### PR TITLE
Feature/per sample bases mask

### DIFF
--- a/digestiflow_demux/Snakefile
+++ b/digestiflow_demux/Snakefile
@@ -7,6 +7,7 @@ from digestiflow_demux.snakemake_support import (
     get_result_files_fastqc,
     get_result_files_demux,
     get_tiles_arg,
+    get_tool_marker,
     wrapper_path,
 )
 
@@ -15,21 +16,8 @@ from digestiflow_demux.bases_mask import return_bases_mask
 # -------------------------------------------------------------------------------------------------
 # Helper Functions
 
-
 def out_prefix(path):
     return os.path.join(config["output_dir"], path)
-
-
-def demux_reads(flowcell, demux_tool):
-    demux_reads = flowcell.get("demux_reads") or flowcell["planned_reads"]
-    planned_reads = flowcell["planned_reads"]
-
-    if demux_tool == "bcl2fastq" and demux_reads == planned_reads:
-        return ""
-    elif demux_tool == "bcl2fastq":
-        return return_bases_mask(planned_reads, demux_reads)
-    else:
-        return return_bases_mask(planned_reads, demux_reads, "picard")
 
 # -------------------------------------------------------------------------------------------------
 # Define local rules.
@@ -49,7 +37,7 @@ rule marker_file:
     input:
         out_prefix("multiqc/multiqc_report.html"),
         out_prefix("multiqc/multiqc_data.zip"),
-        # **get_result_files_fastqc(config),
+        out_prefix(get_tool_marker(config)),
     output: out_prefix("DIGESTIFLOW_DEMUX_DONE.txt"),
     shell:
         r"""
@@ -58,40 +46,92 @@ rule marker_file:
 
 # -------------------------------------------------------------------------------------------------
 # Perform demultiplexing.
+# Use bcl2fastq for flowcells with rta_version 1
 
-if config["demux_tool"] == "bcl2fastq":
-    ruleorder: demux > demux_picard
-elif config["demux_tool"] == "picard" and config["rta_version"] == 2:
-    ruleorder: demux_picard > demux
-else:
-    raise("Picard can only be used with rta version 2 at the moment")
-
-rule demux:
+rule demux_bcl2fastq1:
     input: out_prefix("SampleSheet.csv")
-    output: get_result_files_demux(config)
+    output: get_result_files_demux(config),
+            marker = out_prefix("bcl2fastq1.done")
     params:
         flowcell_token=config["flowcell"]["vendor_id"],
         input_dir=config["input_dir"],
         output_dir=config["output_dir"],
-        read_structure=demux_reads(config["flowcell"], config["demux_tool"]),
         tiles_arg=get_tiles_arg(config),
     threads: config["cores"]
     wrapper: wrapper_path(bcl2fastq_wrapper(config))
 
-# Picard: either take configured lane or all lanes
+# -------------------------------------------------------------------------------------------------
+# bcl2fastq2
+
+# Get list of all bases masks configured, as bcl2fastq2 will be run once for each
+bases_masks = config["flowcell"]["demux_reads_override"]
+keep_undetermined = sorted(bases_masks, reverse=True)[0]  # keep bases mask with longest first read
+
+rule demux_bcl2fastq2_aggregate:
+    input: expand(out_prefix("illumina_basesmask/{bases_mask}/bcl2fastq2.done"), bases_mask = bases_masks)
+    output: fastq = get_result_files_demux(config),
+            marker = out_prefix("bcl2fastq2.done")
+    params:
+        keep_undetermined = keep_undetermined,
+    run:
+        # FASTQ file names are prefixed with their bases mask. Rename them to the expected output.
+        import os
+        import glob
+        from snakemake import shell
+        for final_path in output.fastq:
+            d = os.path.dirname(final_path)
+            f = os.path.basename(final_path)
+            if not "/Undetermined_" in final_path:
+                os.rename(glob.glob(os.path.join(d, "*__" + f))[0], final_path)
+            else:
+                undetermined = glob.glob(os.path.join(d, keep_undetermined + "__" + f))
+                if not undetermined:
+                    undetermined = glob.glob(os.path.join(d, "*__" + f))[0]
+                else:
+                    undetermined = undetermined[0]
+                os.rename(undetermined, final_path)
+        shell(
+            r"""
+            for dest in {output.fastq}; do
+                pushd $(dirname $dest)
+                md5sum $(basename $dest) >$(basename $dest).md5
+                popd
+            done
+            touch {output.marker}
+            """
+            )
+
+rule demux_bcl2fastq2_par:
+    input: sheet = out_prefix("illumina_basesmask/{bases_mask}/SampleSheet.csv")
+    output: marker = out_prefix("illumina_basesmask/{bases_mask}/bcl2fastq2.done")
+    params:
+        flowcell_token=config["flowcell"]["vendor_id"],
+        input_dir=config["input_dir"],
+        output_dir=config["output_dir"],
+        tiles_arg=get_tiles_arg(config),
+    threads: config["cores"]
+    wrapper: wrapper_path(bcl2fastq_wrapper(config))
+
+# -------------------------------------------------------------------------------------------------
+# Picard
+
+# either take configured lane or all lanes
 lanes_to_process = config.get("lanes")
 if not lanes_to_process:
-    lanes_to_process = [x+1 for x in range(config["flowcell"]["num_lanes"])]
+    lanes_to_process = set()
+    for lib in config["flowcell"]["libraries"]:
+        lanes_to_process |= set(lib["lanes"])
 
 rule demux_picard:
     input: metrics=expand(out_prefix("picard_barcodes/{lane}/metrics.txt"), lane=lanes_to_process),
            sheets=expand(out_prefix("picard_barcodes/{lane}/samplesheet.txt"), lane=lanes_to_process)
-    output: get_result_files_demux(config)
+    output: get_result_files_demux(config),
+            marker = out_prefix("picard.done")
     params:
         machine_name=config["flowcell"]["sequencing_machine"],
         flowcell_token=config["flowcell"]["vendor_id"],
         run_number=config["flowcell"]["run_number"],
-        read_structure=demux_reads(config["flowcell"], config["demux_tool"]),
+        read_structure=config["flowcell"]["demux_reads"],
         input_dir=config["input_dir"],
         output_dir=config["output_dir"],
         tiles_arg=get_tiles_arg(config),
@@ -104,7 +144,7 @@ rule prepare_picard:
     output: out_prefix("picard_barcodes/{lane}/metrics.txt")
     params:
         flowcell_token=config["flowcell"]["vendor_id"],
-        read_structure=demux_reads(config["flowcell"], config["demux_tool"]),
+        read_structure=config["flowcell"]["demux_reads"],
         input_dir=config["input_dir"],
     threads: config["cores"]
     wrapper: wrapper_path("picard/extract_barcodes")

--- a/digestiflow_demux/wrappers/bcl2fastq/wrapper.py
+++ b/digestiflow_demux/wrappers/bcl2fastq/wrapper.py
@@ -83,5 +83,7 @@ for path in $srcdir/Undetermined_indices/*/*.fastq.gz; do
     md5sum $(basename $dest) >$(basename $dest).md5
     popd
 done
+
+touch {snakemake.output.marker}
 """
 )

--- a/digestiflow_demux/wrappers/bcl2fastq2/wrapper.py
+++ b/digestiflow_demux/wrappers/bcl2fastq2/wrapper.py
@@ -3,7 +3,12 @@
 This file is part of Digestify Demux.
 """
 
+import glob
+import os
 from snakemake import shell
+
+from digestiflow_demux.bases_mask import return_bases_mask
+from digestiflow_demux.snakemake_support import build_sample_map
 
 __author__ = "Manuel Holtgrewe <manuel.holtgrewe@bihealth.de>"
 
@@ -17,10 +22,14 @@ if barcode_mismatches is None:
 # More than 8 threads will not work for bcl2fastq.
 bcl2fastq_threads = min(8, snakemake.config["cores"])  # noqa
 
-if snakemake.params.read_structure:  # noqa
-    bases_mask = "--use-bases-mask " + snakemake.params.read_structure  # noqa
-else:
-    bases_mask = ""
+# Get bases mask for the current sample sheet
+planned_reads = snakemake.config["flowcell"]["planned_reads"]  # noqa
+bases_mask = os.path.basename(os.path.dirname(snakemake.input.sheet))  # noqa
+bases_mask_illumina = return_bases_mask(planned_reads, bases_mask)
+
+# Get sample map to get sample numbering correct
+sample_map = build_sample_map(snakemake.config["flowcell"])  # noqa
+sample_map["Undetermined"] = "S0"
 
 shell(
     r"""
@@ -36,19 +45,20 @@ trap "rm -rf $TMPDIR" EXIT
 # -------------------------------------------------------------------------------------------------
 # Print Sample Sheet
 
-head -n 10000 {snakemake.params.output_dir}/SampleSheet.csv
+head -n 10000 {snakemake.input.sheet}
 
 # -------------------------------------------------------------------------------------------------
 # Execute bcl2fastq v2
 
 bcl2fastq \
     --barcode-mismatches {barcode_mismatches} \
-    --sample-sheet {snakemake.params.output_dir}/SampleSheet.csv \
+    --sample-sheet {snakemake.input.sheet} \
     --runfolder-dir {snakemake.params.input_dir} \
     --output-dir $TMPDIR/demux_out \
     --interop-dir $TMPDIR/interop_dir \
     --processing-threads {bcl2fastq_threads} \
-    {bases_mask} {snakemake.params.tiles_arg}
+    --use-bases-mask {bases_mask_illumina} \
+    {snakemake.params.tiles_arg}
 
 tree $TMPDIR/demux_out
 
@@ -62,25 +72,45 @@ srcdir=$TMPDIR/demux_out/Project
 for path in $srcdir/*; do
     sample=$(basename $path | rev | cut -d _ -f 5- | rev)
     lane=$(basename $path | rev | cut -d _ -f 3 | rev)
-    dest={snakemake.params.output_dir}/$sample/$flowcell/$lane/$(basename $path)
-
+    dest={snakemake.params.output_dir}/$sample/$flowcell/$lane/{bases_mask}__$(basename $path)
+    mkdir -p $(dirname $dest)
     cp -dR $path $dest
-    pushd $(dirname $dest)
-    md5sum $(basename $dest) >$(basename $dest).md5
-    popd
 done
 
 # Move undetermined FASTQ files.
 srcdir=$TMPDIR/demux_out
 
 for path in $srcdir/Undetermined_*; do
-    lane=$(basename $path | rev | cut -d _ -f 3 | rev)
-    dest={snakemake.params.output_dir}/Undetermined/$flowcell/$lane/$(basename $path)
-
-    cp -dR $path $dest
-    pushd $(dirname $dest)
-    md5sum $(basename $dest) >$(basename $dest).md5
-    popd
+    if [[ -f $path ]]; then
+        lane=$(basename $path | rev | cut -d _ -f 3 | rev)
+        dest={snakemake.params.output_dir}/Undetermined/$flowcell/$lane/{bases_mask}__$(basename $path)
+        mkdir -p $(dirname $dest)
+        cp -dR $path $dest
+    fi
 done
+
+# Write out the html report files as an archive
+srcdir=$TMPDIR/demux_out
+pushd $srcdir
+tar -czvf {snakemake.params.output_dir}/html_report_{bases_mask}.tar.gz Reports
+popd
+
+touch {snakemake.output.marker}
 """
 )
+
+# bcl2fastq2 starts to count samples from 0 for each run. This breaks snakemake's assumption that
+# all samples from all sample sheets are numbered incrementally. Here, we look up the correct
+# sample number and replace it in the path. Easier to do in python than in bash above.
+fls = glob.glob(
+    os.path.join(snakemake.params.output_dir, "*/*/*/" + bases_mask + "__*.fastq.gz")  # noqa
+)
+for path in fls:
+    f = os.path.basename(path)
+    name = f.split("__")[1]  # remove $bases_mask__
+    name_elements = name.split("_")[:-3]
+    oldS = name_elements[-1]
+    name = "_".join(name_elements[:-1])
+    newS = sample_map[name]
+    newpath = path.replace("_".join([name, oldS]), "_".join([name, newS]))
+    os.rename(path, newpath)

--- a/digestiflow_demux/wrappers/picard/basecalls_to_fastq/wrapper.py
+++ b/digestiflow_demux/wrappers/picard/basecalls_to_fastq/wrapper.py
@@ -72,5 +72,7 @@ for sheet in {snakemake.input.sheets}; do
 done
 
 popd
+
+touch {snakemake.output.marker}
 """
 )


### PR DESCRIPTION
Fix #4 and #8 for bcl2fastq2.

* Split bcl2fastq and bcl2fastq2 rule into two rules
* Enable bcl2fastq2 to demultiplex multiple bases masks in parallel with separate sample sheets
* Enable bcl2fastq2 to demultiplex runs with index pools
* Introduce marker file for snakemake to decide which rule (demux_tool) to run
