### PR TITLE
Feature/new server params

### DIFF
--- a/digestiflow_demux/Snakefile
+++ b/digestiflow_demux/Snakefile
@@ -65,7 +65,7 @@ rule demux_bcl2fastq1:
 
 # Get list of all bases masks configured, as bcl2fastq2 will be run once for each
 bases_masks = config["flowcell"]["demux_reads_override"]
-keep_undetermined = sorted(bases_masks, reverse=True)[0]  # keep bases mask with longest first read
+keep_undetermined = config["flowcell"]["demux_reads"]
 
 rule demux_bcl2fastq2_aggregate:
     input: expand(out_prefix("illumina_basesmask/{bases_mask}/bcl2fastq2.done"), bases_mask = bases_masks)
@@ -81,15 +81,22 @@ rule demux_bcl2fastq2_aggregate:
         for final_path in output.fastq:
             d = os.path.dirname(final_path)
             f = os.path.basename(final_path)
-            if not "/Undetermined_" in final_path:
+            if not f.startswith("Undetermined_"):
                 os.rename(glob.glob(os.path.join(d, "*__" + f))[0], final_path)
             else:
                 undetermined = glob.glob(os.path.join(d, keep_undetermined + "__" + f))
                 if not undetermined:
-                    undetermined = glob.glob(os.path.join(d, "*__" + f))[0]
-                else:
-                    undetermined = undetermined[0]
-                os.rename(undetermined, final_path)
+                    undetermined = glob.glob(os.path.join(d, "*__" + f))
+                if undetermined:
+                    os.rename(undetermined[0], final_path)
+                else:  # write a fake fastq if you can't find any, but it is expected
+                    import gzip
+                    os.makedirs(d, exist_ok=True)
+                    with gzip.open(final_path, "wt") as f:
+                        f.write("@placeholder\n")
+                        f.write("N\n")
+                        f.write("+\n")
+                        f.write("!\n")
         shell(
             r"""
             for dest in {output.fastq}; do

--- a/digestiflow_demux/__main__.py
+++ b/digestiflow_demux/__main__.py
@@ -50,6 +50,9 @@ class DemuxConfig:
     #: Select lanes
     lanes = attr.ib()
 
+    #: bcl2fastq2 parameters
+    with_failed_reads = attr.ib()
+
     #: Degree of parallelism to use
     cores = attr.ib()
     #: Increase verbosity
@@ -72,6 +75,7 @@ class DemuxConfig:
             force_demultiplexing=config["web"]["force_demultiplexing"],
             only_post_message=config["web"]["only_post_message"],
             demux_tool=config["demux"]["demux_tool"],
+            with_failed_reads=config["with_failed_reads"],
             project_uuid=config["demux"]["project_uuid"],
             keep_work_dir=config["demux"]["keep_work_dir"],
             work_dir=config["demux"]["work_dir"],
@@ -157,6 +161,9 @@ def merge_config_args(config, args):
     config.setdefault("quiet", False)
     if args.quiet is True:
         config["quiet"] = True
+    config.setdefault("with_failed_reads", False)
+    if args.with_failed_reads is True:
+        config["with_failed_reads"] = True
 
     config["log_api_token"] = args.log_api_token
     config.setdefault("demux", {})["tiles"] = args.tiles
@@ -298,6 +305,7 @@ def main(argv=None):
             "Conflicts with --lane"
         ),
     )
+    parser.add_argument("--with-failed-reads", action="store_true", help=argparse.SUPPRESS)
 
     args = parser.parse_args(argv)
 

--- a/digestiflow_demux/snakemake_support.py
+++ b/digestiflow_demux/snakemake_support.py
@@ -74,12 +74,12 @@ def undetermined_libraries(flowcell):
 
 
 @listify
-def lib_file_names(library, rta_version, n_template, lane=None, seq=None, name=None):
+def lib_file_names(library, rta_version, n_template, n_index, lane=None, seq=None, name=None):
     """Return list with file names for the given library."""
     assert rta_version in (1, 2)
     indices = [library["barcode"] or "NoIndex"]
     reads = ["R" + str(i + 1) for i in range(n_template)]
-    # TODO add I read if keep_index_reads is True
+    reads += ["I" + str(i + 1) for i in range(n_index)]
     lanes = ["L{:03d}".format(lno) for lno in library["lanes"] if lane is None or lno == lane]
     if seq is None:
         seq = ""
@@ -126,6 +126,14 @@ def get_result_files_demux(config):
     sample_map = build_sample_map(flowcell)
     bases_mask = flowcell["demux_reads"]
     n_template = bases_mask.count("T")
+    n_index = (
+        bases_mask.count("B")
+        if (
+            config["bcl2fastq2_params"]["create_fastq_for_index_reads"]
+            and config["demux_tool"] == "bcl2fastq2"
+        )
+        else 0
+    )  # TODO check picard
     expect_undetermined = True if "B" in bases_mask else False
     undetermined = undetermined_libraries(flowcell) if expect_undetermined else []
 
@@ -145,13 +153,13 @@ def get_result_files_demux(config):
             )
 
             if config["rta_version"] == 1 or config["demux_tool"] == "picard":
-                for fname in lib_file_names(lib, config["rta_version"], n_template, lane):
+                for fname in lib_file_names(lib, config["rta_version"], n_template, n_index, lane):
                     yield out_prefix("{out_dir}/{fname}".format(out_dir=out_dir, fname=fname))
             else:
                 seq = sample_map.get(sample_name, "S0")
                 name = "Undetermined" if lib["barcode"] == "Undetermined" else lib["name"]
                 for fname in lib_file_names(
-                    lib, config["rta_version"], n_template, lane, seq, name
+                    lib, config["rta_version"], n_template, n_index, lane, seq, name
                 ):
                     yield out_prefix("{out_dir}/{fname}".format(out_dir=out_dir, fname=fname))
 

--- a/digestiflow_demux/workflow.py
+++ b/digestiflow_demux/workflow.py
@@ -311,6 +311,13 @@ def create_sample_sheet(config, input_dir, output_dir):  # noqa: C901
     else:
         demux_tool = "picard"
 
+    bcl2fastq2_params = {
+        "with_failed_reads": config.with_failed_reads,
+        "create_fastq_for_index_reads": flowcell["create_fastq_for_index_reads"],
+        "minimum_trimmed_read_length": flowcell["minimum_trimmed_read_length"],
+        "mask_short_adapter_reads": flowcell["mask_short_adapter_reads"],
+    }
+
     logging.debug("Writing out demultiplexing configuration")
     # Get barcode mismatch count or default.
     if flowcell["barcode_mismatches"] is None:
@@ -331,6 +338,7 @@ def create_sample_sheet(config, input_dir, output_dir):  # noqa: C901
             "tiles": config.tiles,
             "lanes": config.lanes,
             "demux_tool": demux_tool,
+            "bcl2fastq2_params": bcl2fastq2_params,
         }
         json.dump(config_json, jsonf)
 


### PR DESCRIPTION
* fix handling of Undetermined files. Write out a fake one only in case you absolutely cannot find a proper one, but it is needed for the workflow to finish (i.e. all barcodes are perfect. Otherwise snakemake should not expect Undetermined files to be present, e.g. if it is an un-indexed run)

* add support for some bcl2fastq2 parameters

* close #11, close #14, close #12