### PR TITLE
Fix missing s.locs files in the TARballs

### DIFF
--- a/digestiflow_demux/Snakefile
+++ b/digestiflow_demux/Snakefile
@@ -68,7 +68,8 @@ rule create_tarballs:
             -type f -and \
             -not -path '*Logs*' -and \
             -not -path '*Data*' -and \
-            -not -path '*Thumbnail*' \
+            -not -path '*Thumbnail*'  -or \
+            -name 's.locs' \
          | sort -g \
          > $TMPDIR/files.txt)
 


### PR DESCRIPTION
Adds missing s.locs file to TARballs of iSeq, miSeq, NovaSeq.

https://support.illumina.com/content/dam/illumina-support/documents/documentation/software_documentation/bcl2fastq/bcl2fastq2-v2-20-software-guide-15051736-03.pdf

page 6